### PR TITLE
feat: add ECCANG SDK package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+coverage

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "courier-monorepo",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "test": "pnpm -r test"
+  }
+}

--- a/packages/eccang/package.json
+++ b/packages/eccang/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@courier/eccang",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "fast-xml-parser": "^4.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "@types/nock": "^13.2.5",
+    "nock": "^13.4.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  }
+}

--- a/packages/eccang/src/index.ts
+++ b/packages/eccang/src/index.ts
@@ -1,0 +1,411 @@
+import axios, { AxiosInstance } from 'axios';
+import type {
+  AddressValidateData,
+  AddressValidateRequest,
+  CargoTrackDataItem,
+  CargoTrackRequest,
+  CreateOrderRequest,
+  CreateOrderResponseItem,
+  EccangResponse,
+  FeeTrailQuote,
+  FeeTrailRequest,
+  FieldRuleData,
+  FieldRuleRequest,
+  GetLabelUrlRequest,
+  GetTrackNumberDataItem,
+  GetTrackNumberRequest,
+  GoodsTypeInfo,
+  LabelByTemplateRequest,
+  LabelData,
+  PickupRequest,
+  PrintTemplateInfo,
+  ReceivingExpenseDataItem,
+  ReceivingExpenseRequest,
+  SenderMessage,
+  ShippingMethodInfo,
+  CountryInfo,
+  GenericRecord,
+  CreateOrderVolume,
+  CreateOrderItem
+} from './types';
+import { redactSensitive } from './logger';
+import type { ApiLogEntry, ApiLogger } from './logger';
+
+export interface EccangClientOptions {
+  baseUrl: string;
+  appToken: string;
+  appKey: string;
+  httpClient?: AxiosInstance;
+  logger?: ApiLogger;
+}
+
+const XML_PREFIX =
+  '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://www.example.org/Ec/">\n  <SOAP-ENV:Body>\n    <ns1:callService>';
+const XML_SUFFIX =
+  '    </ns1:callService>\n  </SOAP-ENV:Body>\n</SOAP-ENV:Envelope>';
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function ensureArray<T>(value: T | T[] | undefined): T[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+export class EccangClient {
+  private readonly appToken: string;
+
+  private readonly appKey: string;
+
+  private readonly client: AxiosInstance;
+
+  private readonly logger?: ApiLogger;
+
+  constructor(options: EccangClientOptions) {
+    this.appToken = options.appToken;
+    this.appKey = options.appKey;
+    this.client =
+      options.httpClient ??
+      axios.create({
+        baseURL: options.baseUrl,
+        headers: {
+          'Content-Type': 'text/xml; charset=UTF-8'
+        },
+        timeout: 60_000
+      });
+    this.logger = options.logger;
+  }
+
+  private buildEnvelope(params: unknown, service: string): string {
+    const payload =
+      typeof params === 'string' ? params : JSON.stringify(params ?? {});
+    return [
+      XML_PREFIX,
+      `      <paramsJson><![CDATA[${payload}]]></paramsJson>`,
+      `      <appToken>${this.appToken}</appToken>`,
+      `      <appKey>${this.appKey}</appKey>`,
+      `      <service>${service}</service>`,
+      XML_SUFFIX
+    ].join('\n');
+  }
+
+  private extractResponse<TData>(xml: string): EccangResponse<TData> {
+    const match = xml.match(/<response>([\s\S]*?)<\/response>/i);
+    if (!match) {
+      throw new Error('Unable to parse SOAP response payload.');
+    }
+
+    let jsonPayload = match[1].trim();
+
+    if (jsonPayload.startsWith('<![CDATA[')) {
+      jsonPayload = jsonPayload.slice(9, -3);
+    }
+
+    jsonPayload = decodeXmlEntities(jsonPayload.trim());
+
+    if (!jsonPayload) {
+      throw new Error('Received empty response body.');
+    }
+
+    try {
+      return JSON.parse(jsonPayload) as EccangResponse<TData>;
+    } catch (error) {
+      throw new Error(`Failed to parse ECCANG response JSON: ${(error as Error).message}`);
+    }
+  }
+
+  private async soapCall<TRequest, TResponse>(
+    service: string,
+    params: TRequest
+  ): Promise<EccangResponse<TResponse>> {
+    const envelope = this.buildEnvelope(params, service);
+    const start = Date.now();
+
+    try {
+      const response = await this.client.post('', envelope);
+      const parsed = this.extractResponse<TResponse>(response.data);
+
+      await this.log({
+        service,
+        request: redactSensitive(params),
+        response: redactSensitive(parsed),
+        status: 'success',
+        durationMs: Date.now() - start
+      });
+
+      return parsed;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      await this.log({
+        service,
+        request: redactSensitive(params),
+        status: 'error',
+        durationMs: Date.now() - start,
+        error: { message }
+      });
+
+      throw error;
+    }
+  }
+
+  private async log(entry: ApiLogEntry): Promise<void> {
+    if (!this.logger) {
+      return;
+    }
+
+    await this.logger.log(entry);
+  }
+
+  async createOrder(
+    params: CreateOrderRequest
+  ): Promise<EccangResponse<CreateOrderResponseItem[]>> {
+    return this.soapCall<CreateOrderRequest, CreateOrderResponseItem[]>(
+      'createOrder',
+      params
+    );
+  }
+
+  async batchCreateOrder(
+    params: { order_list: CreateOrderRequest[] }
+  ): Promise<EccangResponse<CreateOrderResponseItem[]>> {
+    return this.soapCall<typeof params, CreateOrderResponseItem[]>(
+      'batchCreateOrder',
+      params
+    );
+  }
+
+  async getTrackNumber(
+    params: GetTrackNumberRequest
+  ): Promise<EccangResponse<GetTrackNumberDataItem[]>> {
+    const result = await this.soapCall<
+      GetTrackNumberRequest,
+      GetTrackNumberDataItem[]
+    >('getTrackNumber', params);
+
+    if (Array.isArray(result.data)) {
+      result.data = result.data.map((item) => ({
+        ...item,
+        trackingnumberlist: item.trackingnumberlist
+          ? Object.fromEntries(
+              Object.entries(item.trackingnumberlist).map(([key, value]) => [
+                key,
+                Array.isArray(value) ? value.join(',') : (value as string)
+              ])
+            )
+          : undefined
+      }));
+    }
+
+    return result;
+  }
+
+  async getLabelUrl(
+    params: GetLabelUrlRequest
+  ): Promise<EccangResponse<LabelData>> {
+    return this.soapCall<GetLabelUrlRequest, LabelData>('getLabelUrl', params);
+  }
+
+  async getCargoTrack(
+    params: CargoTrackRequest
+  ): Promise<EccangResponse<CargoTrackDataItem[]>> {
+    const response = await this.soapCall<CargoTrackRequest, CargoTrackDataItem[]>(
+      'getCargoTrack',
+      params
+    );
+    if (Array.isArray(response.data)) {
+      response.data = response.data.map((item) => ({
+        ...item,
+        Detail: ensureArray(item.Detail)
+      }));
+    }
+    return response;
+  }
+
+  async feeTrail(
+    params: FeeTrailRequest
+  ): Promise<EccangResponse<FeeTrailQuote[]>> {
+    return this.soapCall<FeeTrailRequest, FeeTrailQuote[]>('feeTrail', params);
+  }
+
+  async getReceivingExpense(
+    params: ReceivingExpenseRequest
+  ): Promise<EccangResponse<ReceivingExpenseDataItem[]>> {
+    return this.soapCall<ReceivingExpenseRequest, ReceivingExpenseDataItem[]>(
+      'getReceivingExpense',
+      params
+    );
+  }
+
+  async getShippingMethod(
+    params: GenericRecord
+  ): Promise<EccangResponse<ShippingMethodInfo[]>> {
+    return this.soapCall<GenericRecord, ShippingMethodInfo[]>(
+      'getShippingMethod',
+      params
+    );
+  }
+
+  async getCountry(): Promise<EccangResponse<CountryInfo[]>> {
+    return this.soapCall<Record<string, never>, CountryInfo[]>(
+      'getCountry',
+      {}
+    );
+  }
+
+  async getGoodstype(): Promise<EccangResponse<GoodsTypeInfo[]>> {
+    return this.soapCall<Record<string, never>, GoodsTypeInfo[]>(
+      'getGoodstype',
+      {}
+    );
+  }
+
+  async register(params: GenericRecord): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall('register', params);
+  }
+
+  async getShippingMethodInfo(
+    params: GenericRecord
+  ): Promise<EccangResponse<ShippingMethodInfo[]>> {
+    return this.soapCall<GenericRecord, ShippingMethodInfo[]>(
+      'getShippingMethodInfo',
+      params
+    );
+  }
+
+  async addressValidate(
+    params: AddressValidateRequest
+  ): Promise<EccangResponse<AddressValidateData>> {
+    return this.soapCall<AddressValidateRequest, AddressValidateData>(
+      'addressValidate',
+      params
+    );
+  }
+
+  async checkReferenceNo(
+    params: { reference_no: string }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>('checkReferenceNo', params);
+  }
+
+  async batchGetLabel(
+    params: { reference_nos: string[]; label_type?: number }
+  ): Promise<EccangResponse<LabelData[]>> {
+    return this.soapCall<typeof params, LabelData[]>('batchGetLabel', params);
+  }
+
+  async batchGetPod(
+    params: { reference_nos: string[] }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>('batchGetPod', params);
+  }
+
+  async editOrderSize(
+    params: { reference_no: string; Volume: CreateOrderVolume[] }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>('editOrderSize', params);
+  }
+
+  async modifyOrderWeight(
+    params: { reference_no: string; order_weight: number }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>(
+      'modifyOrderWeight',
+      params
+    );
+  }
+
+  async interceptOrder(
+    params: { reference_no: string; reason?: string }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>('interceptOrder', params);
+  }
+
+  async cancelInterceptOrderByTms(
+    params: { reference_no: string }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>(
+      'cancelInterceptOrderByTms',
+      params
+    );
+  }
+
+  async cancelOrder(
+    params: { reference_no: string }
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<typeof params, GenericRecord>('cancelOrder', params);
+  }
+
+  async getFieldRule(
+    params: FieldRuleRequest
+  ): Promise<EccangResponse<FieldRuleData>> {
+    return this.soapCall<FieldRuleRequest, FieldRuleData>('getFieldRule', params);
+  }
+
+  async getBasicData(
+    params: GenericRecord
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<GenericRecord, GenericRecord>('getBasicData', params);
+  }
+
+  async getPrintTemplateName(
+    params: GenericRecord
+  ): Promise<EccangResponse<PrintTemplateInfo[]>> {
+    return this.soapCall<GenericRecord, PrintTemplateInfo[]>(
+      'getPrintTemplateName',
+      params
+    );
+  }
+
+  async getLabelByTemplate(
+    params: LabelByTemplateRequest
+  ): Promise<EccangResponse<LabelData[]>> {
+    return this.soapCall<LabelByTemplateRequest, LabelData[]>(
+      'getLabelByTemplate',
+      params
+    );
+  }
+
+  async getSenderMessage(
+    params: { reference_no: string }
+  ): Promise<EccangResponse<SenderMessage>> {
+    return this.soapCall<typeof params, SenderMessage>(
+      'getSenderMessage',
+      params
+    );
+  }
+
+  async createUpsPickup(
+    params: PickupRequest
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<PickupRequest, GenericRecord>('createUpsPickup', params);
+  }
+
+  async createMydhlPickup(
+    params: PickupRequest
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<PickupRequest, GenericRecord>(
+      'createMydhlPickup',
+      params
+    );
+  }
+
+  async updateTrackingNumberAndLabel(
+    params: GenericRecord
+  ): Promise<EccangResponse<GenericRecord>> {
+    return this.soapCall<GenericRecord, GenericRecord>(
+      'updateTrackingNumberAndLabel',
+      params
+    );
+  }
+}
+
+export * from './types';
+export * from './logger';

--- a/packages/eccang/src/logger.ts
+++ b/packages/eccang/src/logger.ts
@@ -1,0 +1,52 @@
+export interface ApiLogEntry {
+  service: string;
+  request: unknown;
+  response?: unknown;
+  status: 'success' | 'error';
+  durationMs: number;
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export interface ApiLogger {
+  log(entry: ApiLogEntry): void | Promise<void>;
+}
+
+const SENSITIVE_KEYS = ['token', 'secret', 'password', 'telephone', 'mobile', 'email', 'appToken', 'appKey'];
+
+const MASK = '***';
+
+function maskString(value: string): string {
+  if (value.length <= 3) {
+    return MASK;
+  }
+  return `${value.slice(0, 1)}${MASK}${value.slice(-1)}`;
+}
+
+export function redactSensitive(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const record: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.some((sensitive) => key.toLowerCase().includes(sensitive.toLowerCase()))) {
+        if (typeof val === 'string') {
+          record[key] = maskString(val);
+        } else if (typeof val === 'number') {
+          record[key] = MASK;
+        } else {
+          record[key] = MASK;
+        }
+      } else {
+        record[key] = redactSensitive(val);
+      }
+    }
+    return record;
+  }
+
+  return value;
+}

--- a/packages/eccang/src/types.ts
+++ b/packages/eccang/src/types.ts
@@ -1,0 +1,303 @@
+export type AskStatus = 'Success' | 'Failure';
+
+export interface EccangError {
+  errCode: string;
+  errMessage: string;
+}
+
+export interface EccangResponse<TData> {
+  ask: AskStatus;
+  message?: string;
+  Error?: EccangError | EccangError[] | [];
+  data?: TData;
+  time_cost?: string;
+  [key: string]: unknown;
+}
+
+export interface Consignee {
+  consignee_name: string;
+  telephone?: string;
+  mobile?: string;
+  street?: string;
+  street2?: string;
+  street3?: string;
+  city?: string;
+  province?: string;
+  postcode?: string;
+  email?: string;
+}
+
+export interface Shipper {
+  shipper_name?: string;
+  shipper_company?: string;
+  countrycode?: string;
+  province?: string;
+  city?: string;
+  street?: string;
+  postcode?: string;
+  telephone?: string;
+  mobile?: string;
+  email?: string;
+}
+
+export interface CreateOrderItem {
+  invoice_enname: string;
+  invoice_cnname?: string;
+  invoice_weight: number;
+  invoice_quantity: number;
+  invoice_unitcharge: number;
+  hs_code?: string;
+  sku?: string;
+  invoice_brand?: string;
+  box_number?: string;
+  model?: string;
+  unit_code?: string;
+  is_magnetoelectric?: 'Y' | 'N';
+  [key: string]: unknown;
+}
+
+export interface CreateOrderVolume {
+  length: number;
+  width: number;
+  height: number;
+  weight: number;
+  box_number: string;
+  child_number?: string;
+  [key: string]: unknown;
+}
+
+export interface CreateOrderRequest {
+  reference_no: string;
+  shipping_method: string;
+  country_code: string;
+  order_weight?: number;
+  order_pieces?: number;
+  consignee?: Consignee;
+  shipper?: Shipper;
+  ItemArr?: CreateOrderItem[];
+  Volume?: CreateOrderVolume[];
+  [key: string]: unknown;
+}
+
+export interface CreateOrderResponseItem {
+  reference_no: string;
+  shipping_method_no: string;
+  order_code: string;
+  track_status: string;
+  sender_info_status?: string;
+  ODA?: string;
+  agent_number?: string;
+  [key: string]: unknown;
+}
+
+export interface GetTrackNumberRequest {
+  reference_no: string[];
+}
+
+export interface TrackingNumberList {
+  [boxNumber: string]: string;
+}
+
+export interface GetTrackNumberDataItem {
+  OrderNumber: string;
+  TrackingNumber?: string;
+  WayBillNumber?: string;
+  PlatformNumber?: string;
+  channelGroupCode?: string;
+  channelNumber?: string;
+  trackingnumberlist?: TrackingNumberList;
+  [key: string]: unknown;
+}
+
+export interface GetLabelUrlRequest {
+  reference_no: string;
+  type?: 1 | 2 | 3;
+  label_type?: 1 | 2 | 3;
+  label_content_type?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+}
+
+export interface LabelData {
+  ask: AskStatus;
+  message?: string;
+  type?: string;
+  url?: string;
+  invoice_url?: string;
+  reference_no?: string;
+  [key: string]: unknown;
+}
+
+export interface CargoTrackRequest {
+  codes: string[];
+  type?: string | null;
+  lang?: 'EN' | 'CN' | string;
+}
+
+export interface CargoTrackDetail {
+  OccurDate?: string;
+  Comment?: string;
+  StatusCode?: string;
+  Area?: string;
+  [key: string]: unknown;
+}
+
+export interface CargoTrackDataItem {
+  Code: string;
+  Country_code?: string;
+  New_date?: string;
+  New_Comment?: string;
+  Status?: string;
+  WaybillNumber?: string;
+  TrackingNumber?: string;
+  product_code?: string;
+  product_name?: string;
+  Detail?: CargoTrackDetail[];
+  [key: string]: unknown;
+}
+
+export interface FeeTrailRequest {
+  country_code: string;
+  weight: string;
+  length?: string;
+  width?: string;
+  height?: string;
+  shipping_type_id: string;
+  group?: string;
+  [key: string]: unknown;
+}
+
+export interface FeeTrailQuote {
+  ServiceCode: string;
+  ServiceCnName?: string;
+  ServiceEnName?: string;
+  FreightFee?: string;
+  FuelFee?: string;
+  RegisteredFee?: string;
+  OtherFee?: string;
+  TotalFee?: string;
+  Effectiveness?: string;
+  Traceability?: string;
+  VolumeCharge?: string;
+  Remark?: string;
+  ChargeWeight?: string;
+  ChargeWeightUnit?: string;
+  ProductSort?: string;
+  Formula?: string;
+  [key: string]: unknown;
+}
+
+export interface SimpleCodeName {
+  code: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface CountryInfo {
+  country_code: string;
+  country_cn?: string;
+  country_en?: string;
+  [key: string]: unknown;
+}
+
+export interface GoodsTypeInfo {
+  goods_type_id: string;
+  goods_type_name?: string;
+  goods_type_name_en?: string;
+  [key: string]: unknown;
+}
+
+export interface ShippingMethodInfo {
+  shipping_method: string;
+  shipping_method_en?: string;
+  shipping_method_cn?: string;
+  channel_code?: string;
+  [key: string]: unknown;
+}
+
+export interface AddressValidateRequest {
+  shipping_method: string;
+  country_code: string;
+  province?: string;
+  postcode?: string;
+  city?: string;
+  consignee?: Consignee;
+  ItemArr?: CreateOrderItem[];
+  [key: string]: unknown;
+}
+
+export interface AddressValidateData {
+  ask: AskStatus;
+  message?: string;
+  ErrorMessage?: string;
+  [key: string]: unknown;
+}
+
+export interface FieldRuleRequest {
+  shipping_method: string;
+  country_code: string;
+  [key: string]: unknown;
+}
+
+export interface FieldRuleField {
+  field: string;
+  required: boolean;
+  label?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface FieldRuleData {
+  consignee?: FieldRuleField[];
+  shipper?: FieldRuleField[];
+  ItemArr?: FieldRuleField[];
+  Volume?: FieldRuleField[];
+  [key: string]: unknown;
+}
+
+export interface ReceivingExpenseRequest {
+  reference_no: string;
+}
+
+export interface ReceivingExpenseDataItem {
+  reference_no: string;
+  Freight?: string;
+  Register?: string;
+  FuelCharge?: string;
+  OtherFee?: string;
+  TotalFee?: string;
+  [key: string]: unknown;
+}
+
+export type GenericRecord = Record<string, unknown>;
+
+export interface PickupRequest {
+  reference_no: string;
+  [key: string]: unknown;
+}
+
+export interface PrintTemplateInfo {
+  template_name: string;
+  template_code: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface LabelByTemplateRequest {
+  template_code: string;
+  codes: string[];
+  [key: string]: unknown;
+}
+
+export interface SenderMessage {
+  reference_no: string;
+  shipper_name?: string;
+  shipper_company?: string;
+  shipper_country?: string;
+  shipper_province?: string;
+  shipper_city?: string;
+  shipper_street?: string;
+  shipper_postcode?: string;
+  shipper_telephone?: string;
+  shipper_mobile?: string;
+  shipper_email?: string;
+  [key: string]: unknown;
+}

--- a/packages/eccang/tests/eccang-client.spec.ts
+++ b/packages/eccang/tests/eccang-client.spec.ts
@@ -1,0 +1,122 @@
+import nock from 'nock';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EccangClient } from '../src';
+import type { ApiLogEntry } from '../src';
+
+const BASE_URL = 'http://example.com/default/svc/web-service';
+
+describe('EccangClient', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    expect(nock.isDone()).toBe(true);
+    nock.cleanAll();
+  });
+
+  it('sends a createOrder request and parses the response payload', async () => {
+    const logs: ApiLogEntry[] = [];
+    const client = new EccangClient({
+      baseUrl: BASE_URL,
+      appToken: 'token',
+      appKey: 'key',
+      logger: {
+        log: (entry) => {
+          logs.push(entry);
+        }
+      }
+    });
+
+    const responseEnvelope =
+      '<SOAP-ENV:Envelope><SOAP-ENV:Body><ns1:callServiceResponse><response><![CDATA[{"ask":"Success","message":"Created","data":[{"reference_no":"REF123","order_code":"OC123","shipping_method_no":"SM001","track_status":"1"}]}]]></response></ns1:callServiceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+
+    nock('http://example.com')
+      .post('/default/svc/web-service', (body) => {
+        const xml = String(body);
+        expect(xml).toContain('<service>createOrder</service>');
+        expect(xml).toContain('<appToken>token</appToken>');
+        expect(xml).toContain('<appKey>key</appKey>');
+        expect(xml).toContain('<paramsJson><![CDATA[{"reference_no":"REF123","shipping_method":"SM","country_code":"US"');
+        return true;
+      })
+      .reply(200, responseEnvelope, { 'Content-Type': 'text/xml' });
+
+    const result = await client.createOrder({
+      reference_no: 'REF123',
+      shipping_method: 'SM',
+      country_code: 'US',
+      consignee: {
+        consignee_name: 'John Doe',
+        email: 'john@example.com'
+      }
+    });
+
+    expect(result.ask).toBe('Success');
+    expect(result.data?.[0]?.order_code).toBe('OC123');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].status).toBe('success');
+    expect(logs[0].request).toMatchObject({
+      consignee: { email: 'j***m' }
+    });
+  });
+
+  it('normalises cargo track detail entries into arrays', async () => {
+    const client = new EccangClient({
+      baseUrl: BASE_URL,
+      appToken: 'token',
+      appKey: 'key'
+    });
+
+    const responseEnvelope =
+      '<SOAP-ENV:Envelope><SOAP-ENV:Body><ns1:callServiceResponse><response>{"ask":"Success","data":[{"Code":"C1","Detail":{"OccurDate":"2024-01-01 10:00:00","Comment":"In transit"}}]}</response></ns1:callServiceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+
+    nock('http://example.com')
+      .post('/default/svc/web-service')
+      .reply(200, responseEnvelope, { 'Content-Type': 'text/xml' });
+
+    const result = await client.getCargoTrack({ codes: ['C1'], lang: 'EN', type: null });
+    expect(result.data).toBeDefined();
+    expect(result.data?.[0].Detail).toEqual([
+      {
+        OccurDate: '2024-01-01 10:00:00',
+        Comment: 'In transit'
+      }
+    ]);
+  });
+
+  it('normalises tracking number maps', async () => {
+    const client = new EccangClient({
+      baseUrl: BASE_URL,
+      appToken: 'token',
+      appKey: 'key'
+    });
+
+    const responseEnvelope =
+      '<SOAP-ENV:Envelope><SOAP-ENV:Body><ns1:callServiceResponse><response>{"ask":"Success","data":[{"OrderNumber":"REF123","trackingnumberlist":{"U001":["TRK123"]}}]}</response></ns1:callServiceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+
+    nock('http://example.com')
+      .post('/default/svc/web-service')
+      .reply(200, responseEnvelope, { 'Content-Type': 'text/xml' });
+
+    const result = await client.getTrackNumber({ reference_no: ['REF123'] });
+    expect(result.data?.[0].trackingnumberlist?.U001).toBe('TRK123');
+  });
+
+  it('throws a descriptive error when the SOAP body is not valid JSON', async () => {
+    const client = new EccangClient({
+      baseUrl: BASE_URL,
+      appToken: 'token',
+      appKey: 'key'
+    });
+
+    const responseEnvelope =
+      '<SOAP-ENV:Envelope><SOAP-ENV:Body><ns1:callServiceResponse><response>not-json</response></ns1:callServiceResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+
+    nock('http://example.com')
+      .post('/default/svc/web-service')
+      .reply(200, responseEnvelope, { 'Content-Type': 'text/xml' });
+
+    await expect(client.getCountry()).rejects.toThrow('Failed to parse ECCANG response JSON');
+  });
+});

--- a/packages/eccang/tsconfig.build.json
+++ b/packages/eccang/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests"]
+}

--- a/packages/eccang/tsconfig.json
+++ b/packages/eccang/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/eccang/vitest.config.ts
+++ b/packages/eccang/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.spec.ts']
+  }
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a pnpm workspace with an ECCANG SDK package
- implement a typed SOAP client that wraps core ECCANG services
- add Vitest + nock based tests covering request formatting, parsing, and logging redaction

## Testing
- pnpm install *(fails: unable to download pnpm due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd735a34d48327a1b0852f890734ea